### PR TITLE
Expose REST and gRPC endpoints via Traefik

### DIFF
--- a/babylon.yml
+++ b/babylon.yml
@@ -42,6 +42,7 @@ services:
       - CL_GRPC_PORT=${CL_GRPC_PORT:-9090}
       - CL_P2P_PORT=${CL_P2P_PORT:-26656}
       - CL_RPC_PORT=${CL_RPC_PORT:-26657}
+      - CL_REST_PORT=${CL_REST_PORT:-1317}
       - RPC_PORT=${RPC_PORT:-8545}
       - WS_PORT=${WS_PORT:-8546}
       - SNAPSHOT=${SNAPSHOT}
@@ -98,6 +99,24 @@ services:
         - traefik.http.routers.${WS_HOST:-babylonws}lb.rule=Host(`${WS_LB:-babylonws-lb}.${DOMAIN}`)
         - traefik.http.routers.${WS_HOST:-babylonws}lb.tls.certresolver=letsencrypt
         - traefik.http.services.${WS_HOST:-babylonws}.loadbalancer.server.port=${WS_PORT:-8546}
+        - traefik.http.routers.${REST_HOST}.service=${REST_HOST}
+        - traefik.http.routers.${REST_HOST}.entrypoints=websecure
+        - traefik.http.routers.${REST_HOST}.rule=Host(`${REST_HOST}.${DOMAIN}`)
+        - traefik.http.routers.${REST_HOST}.tls.certresolver=letsencrypt
+        - traefik.http.routers.${REST_HOST}lb.service=${REST_HOST}
+        - traefik.http.routers.${REST_HOST}lb.entrypoints=websecure
+        - traefik.http.routers.${REST_HOST}lb.rule=Host(`${REST_LB}.${DOMAIN}`)
+        - traefik.http.routers.${REST_HOST}lb.tls.certresolver=letsencrypt
+        - traefik.http.services.${REST_HOST}.loadbalancer.server.port=${CL_REST_PORT}
+        - traefik.http.routers.${GRPC_HOST}.service=${GRPC_HOST}
+        - traefik.http.routers.${GRPC_HOST}.entrypoints=websecure
+        - traefik.http.routers.${GRPC_HOST}.rule=Host(`${GRPC_HOST}.${DOMAIN}`)
+        - traefik.http.routers.${GRPC_HOST}.tls.certresolver=letsencrypt
+        - traefik.http.routers.${GRPC_HOST}lb.service=${GRPC_HOST}
+        - traefik.http.routers.${GRPC_HOST}lb.entrypoints=websecure
+        - traefik.http.routers.${GRPC_HOST}lb.rule=Host(`${GRPC_LB}.${DOMAIN}`)
+        - traefik.http.routers.${GRPC_HOST}lb.tls.certresolver=letsencrypt
+        - traefik.http.services.${GRPC_HOST}.loadbalancer.server.port=${CL_GRPC_PORT}
         - metrics.scrape=true
         - metrics.path=/metrics
         - metrics.port=26660
@@ -253,7 +272,7 @@ services:
         babylond keys add $MONIKER --keyring-backend test --home /cosmos 2>&1 | tee /tmp/temp_backup
         [ $${PIPESTATUS[0]} -eq 0 ] && sed -n '/- address/,$$p' /tmp/temp_backup > "/cosmos/keyring-test/${MONIKER}.backup" || rm /tmp/temp_backup
         chown -R babylon:babylon /cosmos/keyring-test/*
-  
+
   create-bls-key:
     profiles: ["tools"]
     build:

--- a/babylon/docker-entrypoint.sh
+++ b/babylon/docker-entrypoint.sh
@@ -109,6 +109,8 @@ dasel put -f /cosmos/config/app.toml -v "0.0.0.0:${RPC_PORT}" json-rpc.address
 dasel put -f /cosmos/config/app.toml -v "0.0.0.0:${WS_PORT}" json-rpc.ws-address
 dasel put -f /cosmos/config/app.toml -v "0.0.0.0:${CL_GRPC_PORT}" grpc.address
 dasel put -f /cosmos/config/app.toml -v true grpc.enable
+dasel put -f /cosmos/config/app.toml -v "tcp://0.0.0.0:${CL_REST_PORT}" api.address
+dasel put -f /cosmos/config/app.toml -t bool -v true api.enable
 dasel put -f /cosmos/config/app.toml -v "${MIN_GAS_PRICE}" "minimum-gas-prices"
 dasel put -f /cosmos/config/app.toml -v 0 "iavl-cache-size"
 dasel put -f /cosmos/config/app.toml -v "true" "iavl-disable-fastnode"

--- a/default.env
+++ b/default.env
@@ -21,6 +21,7 @@ SNAPSHOT=
 CL_GRPC_PORT=9090
 CL_P2P_PORT=26656
 CL_RPC_PORT=26657
+CL_REST_PORT=1317
 CL_SIGNER_PORT=26659
 RPC_PORT=8545
 WS_PORT=8546
@@ -37,6 +38,10 @@ RPC_HOST=babylon
 RPC_LB=babylon-lb
 WS_HOST=babylonws
 WS_LB=babylonws-lb
+REST_HOST=babylon-api
+REST_LB=babylon-api-lb
+GRPC_HOST=babylon-grpc
+GRPC_LB=babylon-grpc-lb
 
 # External Docker network if using ext-network.yml
 DOCKER_EXT_NETWORK=traefik_default

--- a/rpc-shared.yml
+++ b/rpc-shared.yml
@@ -2,6 +2,7 @@
 services:
   babylon:
     ports:
-      - ${CL_RPC_PORT:-26657}:${CL_RPC_PORT:-26657}/tcp
+      - ${CL_RPC_PORT:-26657}:${CL_RPC_PORT:-26657}/
+      - ${CL_REST_PORT:-1317}:${CL_REST_PORT:-1317}/tcp
       - ${RPC_PORT:-8545}:${RPC_PORT:-8545}/tcp
       - ${WS_PORT:-8546}:${WS_PORT:-8546}/tcp

--- a/rpc-shared.yml
+++ b/rpc-shared.yml
@@ -2,7 +2,7 @@
 services:
   babylon:
     ports:
-      - ${CL_RPC_PORT:-26657}:${CL_RPC_PORT:-26657}/
+      - ${CL_RPC_PORT:-26657}:${CL_RPC_PORT:-26657}/tcp
       - ${CL_REST_PORT:-1317}:${CL_REST_PORT:-1317}/tcp
       - ${RPC_PORT:-8545}:${RPC_PORT:-8545}/tcp
       - ${WS_PORT:-8546}:${WS_PORT:-8546}/tcp


### PR DESCRIPTION
Adds environment variables for REST and gRPC ports and hostnames.
Configures Traefik routing rules for the new REST and gRPC services.
Updates the application entrypoint script to enable the REST API endpoint.
Exposes the REST port in the Docker Compose service definition.