### PR TITLE
BCE-6965 New config values for Babylon finality hotfix

### DIFF
--- a/eotsd/docker-entrypoint.sh
+++ b/eotsd/docker-entrypoint.sh
@@ -12,7 +12,7 @@ echo "Initialization complete. Ready to start eotsd."
 
 sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/eotsd/eotsd.conf
 # Add GRPCMaxContentLength if not present
-if ! grep -q '^GRPCMaxContentLength' /data/eotsd/eotsd.conf; then
+if grep -q '^GRPCMaxContentLength' /data/eotsd/eotsd.conf; then
   # Update existing GRPCMaxContentLength value to 16777216
   sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/eotsd/eotsd.conf
 else

--- a/eotsd/docker-entrypoint.sh
+++ b/eotsd/docker-entrypoint.sh
@@ -11,6 +11,17 @@ fi
 echo "Initialization complete. Ready to start eotsd."
 
 sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/eotsd/eotsd.conf
+# Add GRPCMaxContentLength if not present
+if ! grep -q '^GRPCMaxContentLength' /data/eotsd/eotsd.conf; then
+  cat <<EOF >> /data/eotsd/eotsd.conf
+[Application Options]
+; The maximum size of the gRPC message in bytes.
+GRPCMaxContentLength = 16777216
+EOF
+else
+  # Update existing GRPCMaxContentLength value to 16777216
+  sed -i 's/^\(\s*GRPCMaxContentLength\s*=\s*\).*/\1 16777216/' /data/eotsd/eotsd.conf
+fi
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086

--- a/eotsd/docker-entrypoint.sh
+++ b/eotsd/docker-entrypoint.sh
@@ -20,7 +20,7 @@ GRPCMaxContentLength = 16777216
 EOF
 else
   # Update existing GRPCMaxContentLength value to 16777216
-  sed -i 's/^\(\s*GRPCMaxContentLength\s*=\s*\).*/\1 16777216/' /data/eotsd/eotsd.conf
+  sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/eotsd/eotsd.conf
 fi
 
 # Word splitting is desired for the command line parameters

--- a/eotsd/docker-entrypoint.sh
+++ b/eotsd/docker-entrypoint.sh
@@ -11,16 +11,18 @@ fi
 echo "Initialization complete. Ready to start eotsd."
 
 sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/eotsd/eotsd.conf
-# Add GRPCMaxContentLength if not present
-if grep -q '^GRPCMaxContentLength' /data/eotsd/eotsd.conf; then
-  # Update existing GRPCMaxContentLength value to 16777216
-  sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/eotsd/eotsd.conf
-else
-  cat <<EOF >> /data/eotsd/eotsd.conf
+if [ "$NETWORK" = "bbn-test-5" ]; then
+  # Add GRPCMaxContentLength if not present
+  if grep -q '^GRPCMaxContentLength' /data/eotsd/eotsd.conf; then
+    # Update existing GRPCMaxContentLength value to 16777216
+    sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/eotsd/eotsd.conf
+  else
+    cat <<EOF >> /data/eotsd/eotsd.conf
 [Application Options]
 ; The maximum size of the gRPC message in bytes.
 GRPCMaxContentLength = 16777216
 EOF
+  fi
 fi
 
 # Word splitting is desired for the command line parameters

--- a/eotsd/docker-entrypoint.sh
+++ b/eotsd/docker-entrypoint.sh
@@ -13,14 +13,14 @@ echo "Initialization complete. Ready to start eotsd."
 sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/eotsd/eotsd.conf
 # Add GRPCMaxContentLength if not present
 if ! grep -q '^GRPCMaxContentLength' /data/eotsd/eotsd.conf; then
+  # Update existing GRPCMaxContentLength value to 16777216
+  sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/eotsd/eotsd.conf
+else
   cat <<EOF >> /data/eotsd/eotsd.conf
 [Application Options]
 ; The maximum size of the gRPC message in bytes.
 GRPCMaxContentLength = 16777216
 EOF
-else
-  # Update existing GRPCMaxContentLength value to 16777216
-  sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/eotsd/eotsd.conf
 fi
 
 # Word splitting is desired for the command line parameters

--- a/fpd/docker-entrypoint.sh
+++ b/fpd/docker-entrypoint.sh
@@ -16,15 +16,35 @@ sed -i "s|^EOTSManagerAddress = .*|EOTSManagerAddress = ${EOTSD_HOST}|" /data/fp
 sed -i "s|^RPCAddr = .*|RPCAddr = ${BABYLOND_HOST}|" /data/fpd/fpd.conf
 sed -i "s|^ChainID = .*|ChainID = ${NETWORK}|" /data/fpd/fpd.conf
 sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/fpd/fpd.conf
-sed -i 's/^\(\s*BatchSubmissionSize\s*=\s*\).*/\1 100/' /data/fpd/fpd.conf
+# sed -i 's/^\(\s*BatchSubmissionSize\s*=\s*\).*/\1 100/' /data/fpd/fpd.conf
+sed -i 's/^\(\s*BatchSubmissionSize\s*=\s*\).*/\1 250/' /data/fpd/fpd.conf
+sed -i 's/^\(\s*BufferSize\s*=\s*\).*/\1 10000/' /data/fpd/fpd.conf
+sed -i 's/^\(\s*PollInterval\s*=\s*\).*/\1 200ms/' /data/fpd/fpd.conf
 
 if sed -n '/\[chainpollerconfig\]/,/^\[/p' /data/fpd/fpd.conf | grep -q 'PollSize'; then
   # Update the existing PollSize value
-  sed -i '/\[chainpollerconfig\]/,/\[/ s/^\(\s*PollSize\s*=\s*\).*/\1 100/' /data/fpd/fpd.conf
+  sed -i '/\[chainpollerconfig\]/,/\[/ s/^\(\s*PollSize\s*=\s*\).*/\1 20/' /data/fpd/fpd.conf
 else
   # Append PollSize after BufferSize if PollSize is not present
-  sed -i '/BufferSize = 1000/a PollSize = 100' /data/fpd/fpd.conf
+  sed -i '/BufferSize = 10000/a PollSize = 20' /data/fpd/fpd.conf
 fi
+
+# Add GRPCMaxContentLength and UnsafeResetLastVotedHeight if not present
+if ! grep -q '^GRPCMaxContentLength' /data/fpd/fpd.conf; then
+  cat <<EOF >> /data/fpd/fpd.conf
+[Application Options]
+; The maximum size of the gRPC message in bytes.
+GRPCMaxContentLength = 16777216
+
+; WARNING: If set to 'true', resets the finality provider's last voted height to the calculated start height from poller. WARNING
+UnsafeResetLastVotedHeight = true
+EOF
+else
+  # Update existing GRPCMaxContentLength value to 16777216 and UnsafeResetLastVotedHeight to true
+  sed -i 's/^\(\s*GRPCMaxContentLength\s*=\s*\).*/\1 16777216/' /data/fpd/fpd.conf
+  sed -i 's/^\(\s*UnsafeResetLastVotedHeight\s*=\s*\).*/\1 true/' /data/fpd/fpd.conf
+fi
+
 
 # Word splitting is desired for the command line parameters
 # shellcheck disable=SC2086

--- a/fpd/docker-entrypoint.sh
+++ b/fpd/docker-entrypoint.sh
@@ -16,26 +16,38 @@ sed -i "s|^EOTSManagerAddress = .*|EOTSManagerAddress = ${EOTSD_HOST}|" /data/fp
 sed -i "s|^RPCAddr = .*|RPCAddr = ${BABYLOND_HOST}|" /data/fpd/fpd.conf
 sed -i "s|^ChainID = .*|ChainID = ${NETWORK}|" /data/fpd/fpd.conf
 sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/fpd/fpd.conf
-sed -i 's/^BatchSubmissionSize[[:space:]]*=[[:space:]]*.*/BatchSubmissionSize = 250/' /data/fpd/fpd.conf
-sed -i 's/^BufferSize[[:space:]]*=[[:space:]]*.*/BufferSize = 10000/' /data/fpd/fpd.conf
-sed -i 's/^PollInterval[[:space:]]*=[[:space:]]*.*/PollInterval = 200ms/' /data/fpd/fpd.conf
-sed -i 's/^TimestampingDelayBlocks[[:space:]]*=[[:space:]]*.*/TimestampingDelayBlocks = 60000/' /data/fpd/fpd.conf
-sed -i 's/^NumPubRand[[:space:]]*=[[:space:]]*.*/NumPubRand = 100000/' /data/fpd/fpd.conf
+sed -i 's/^\(\s*BatchSubmissionSize\s*=\s*\).*/\1 100/' /data/fpd/fpd.conf
 
 if sed -n '/\[chainpollerconfig\]/,/^\[/p' /data/fpd/fpd.conf | grep -q 'PollSize'; then
   # Update the existing PollSize value
-  sed -i '/\[chainpollerconfig\]/,/\[/ s/^\(\s*PollSize\s*=\s*\).*/\1 20/' /data/fpd/fpd.conf
+  sed -i '/\[chainpollerconfig\]/,/\[/ s/^\(\s*PollSize\s*=\s*\).*/\1 100/' /data/fpd/fpd.conf
 else
   # Append PollSize after BufferSize if PollSize is not present
-  sed -i '/BufferSize = 10000/a PollSize = 20' /data/fpd/fpd.conf
+  sed -i '/BufferSize = 1000/a PollSize = 100' /data/fpd/fpd.conf
 fi
 
-# Add GRPCMaxContentLength and UnsafeResetLastVotedHeight if not present
-if grep -q '^GRPCMaxContentLength' /data/fpd/fpd.conf; then
-  sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/fpd/fpd.conf
-  sed -i 's/^UnsafeResetLastVotedHeight[[:space:]]*=[[:space:]]*.*/UnsafeResetLastVotedHeight = true/' /data/fpd/fpd.conf
-else
-  cat <<EOF >> /data/fpd/fpd.conf
+# Testnet only changes from hotfix
+if [ "$NETWORK" = "bbn-test-5" ]; then
+  sed -i 's/^BatchSubmissionSize[[:space:]]*=[[:space:]]*.*/BatchSubmissionSize = 250/' /data/fpd/fpd.conf
+  sed -i 's/^BufferSize[[:space:]]*=[[:space:]]*.*/BufferSize = 10000/' /data/fpd/fpd.conf
+  sed -i 's/^PollInterval[[:space:]]*=[[:space:]]*.*/PollInterval = 200ms/' /data/fpd/fpd.conf
+  sed -i 's/^TimestampingDelayBlocks[[:space:]]*=[[:space:]]*.*/TimestampingDelayBlocks = 60000/' /data/fpd/fpd.conf
+  sed -i 's/^NumPubRand[[:space:]]*=[[:space:]]*.*/NumPubRand = 100000/' /data/fpd/fpd.conf
+
+  if sed -n '/\[chainpollerconfig\]/,/^\[/p' /data/fpd/fpd.conf | grep -q 'PollSize'; then
+    # Update the existing PollSize value
+    sed -i '/\[chainpollerconfig\]/,/\[/ s/^\(\s*PollSize\s*=\s*\).*/\1 20/' /data/fpd/fpd.conf
+  else
+    # Append PollSize after BufferSize if PollSize is not present
+    sed -i '/BufferSize = 10000/a PollSize = 20' /data/fpd/fpd.conf
+  fi
+
+  # Add GRPCMaxContentLength and UnsafeResetLastVotedHeight if not present
+  if grep -q '^GRPCMaxContentLength' /data/fpd/fpd.conf; then
+    sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/fpd/fpd.conf
+    sed -i 's/^UnsafeResetLastVotedHeight[[:space:]]*=[[:space:]]*.*/UnsafeResetLastVotedHeight = true/' /data/fpd/fpd.conf
+  else
+    cat <<EOF >> /data/fpd/fpd.conf
 [Application Options]
 ; The maximum size of the gRPC message in bytes.
 GRPCMaxContentLength = 16777216
@@ -43,6 +55,7 @@ GRPCMaxContentLength = 16777216
 ; WARNING: If set to 'true', resets the finality provider's last voted height to the calculated start height from poller. WARNING
 UnsafeResetLastVotedHeight = true
 EOF
+  fi
 fi
 
 

--- a/fpd/docker-entrypoint.sh
+++ b/fpd/docker-entrypoint.sh
@@ -28,32 +28,31 @@ fi
 
 # Testnet only changes from hotfix
 if [ "$NETWORK" = "bbn-test-5" ]; then
-  sed -i 's/^BatchSubmissionSize[[:space:]]*=[[:space:]]*.*/BatchSubmissionSize = 250/' /data/fpd/fpd.conf
-  sed -i 's/^BufferSize[[:space:]]*=[[:space:]]*.*/BufferSize = 10000/' /data/fpd/fpd.conf
-  sed -i 's/^PollInterval[[:space:]]*=[[:space:]]*.*/PollInterval = 200ms/' /data/fpd/fpd.conf
-  sed -i 's/^TimestampingDelayBlocks[[:space:]]*=[[:space:]]*.*/TimestampingDelayBlocks = 60000/' /data/fpd/fpd.conf
-  sed -i 's/^NumPubRand[[:space:]]*=[[:space:]]*.*/NumPubRand = 100000/' /data/fpd/fpd.conf
+  sed -i 's/^BatchSubmissionSize[[:space:]]*=[[:space:]]*.*/BatchSubmissionSize = 1000/' /data/fpd/fpd.conf
+  sed -i 's/^BufferSize[[:space:]]*=[[:space:]]*.*/BufferSize = 1000/' /data/fpd/fpd.conf
+  sed -i 's/^PollInterval[[:space:]]*=[[:space:]]*.*/PollInterval = 1s/' /data/fpd/fpd.conf
+  sed -i 's/^TimestampingDelayBlocks[[:space:]]*=[[:space:]]*.*/TimestampingDelayBlocks = 80000/' /data/fpd/fpd.conf
+  sed -i 's/^NumPubRand[[:space:]]*=[[:space:]]*.*/NumPubRand = 160000/' /data/fpd/fpd.conf
+  # this removes an old testnet value that we no longer need
+  sed -i '/^UnsafeResetLastVotedHeight[[:space:]]*=[[:space:]]*true$/d' /data/fpd/fpd.conf
 
   if sed -n '/\[chainpollerconfig\]/,/^\[/p' /data/fpd/fpd.conf | grep -q 'PollSize'; then
     # Update the existing PollSize value
-    sed -i '/\[chainpollerconfig\]/,/\[/ s/^\(\s*PollSize\s*=\s*\).*/\1 20/' /data/fpd/fpd.conf
+    sed -i '/\[chainpollerconfig\]/,/\[/ s/^\(\s*PollSize\s*=\s*\).*/\1 1000/' /data/fpd/fpd.conf
   else
     # Append PollSize after BufferSize if PollSize is not present
-    sed -i '/BufferSize = 10000/a PollSize = 20' /data/fpd/fpd.conf
+    sed -i '/BufferSize = 1000/a PollSize = 1000' /data/fpd/fpd.conf
   fi
 
   # Add GRPCMaxContentLength and UnsafeResetLastVotedHeight if not present
   if grep -q '^GRPCMaxContentLength' /data/fpd/fpd.conf; then
     sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/fpd/fpd.conf
-    sed -i 's/^UnsafeResetLastVotedHeight[[:space:]]*=[[:space:]]*.*/UnsafeResetLastVotedHeight = true/' /data/fpd/fpd.conf
+
   else
     cat <<EOF >> /data/fpd/fpd.conf
 [Application Options]
 ; The maximum size of the gRPC message in bytes.
 GRPCMaxContentLength = 16777216
-
-; WARNING: If set to 'true', resets the finality provider's last voted height to the calculated start height from poller. WARNING
-UnsafeResetLastVotedHeight = true
 EOF
   fi
 fi

--- a/fpd/docker-entrypoint.sh
+++ b/fpd/docker-entrypoint.sh
@@ -16,10 +16,9 @@ sed -i "s|^EOTSManagerAddress = .*|EOTSManagerAddress = ${EOTSD_HOST}|" /data/fp
 sed -i "s|^RPCAddr = .*|RPCAddr = ${BABYLOND_HOST}|" /data/fpd/fpd.conf
 sed -i "s|^ChainID = .*|ChainID = ${NETWORK}|" /data/fpd/fpd.conf
 sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/fpd/fpd.conf
-# sed -i 's/^\(\s*BatchSubmissionSize\s*=\s*\).*/\1 100/' /data/fpd/fpd.conf
-sed -i 's/^\(\s*BatchSubmissionSize\s*=\s*\).*/\1 250/' /data/fpd/fpd.conf
-sed -i 's/^\(\s*BufferSize\s*=\s*\).*/\1 10000/' /data/fpd/fpd.conf
-sed -i 's/^\(\s*PollInterval\s*=\s*\).*/\1 200ms/' /data/fpd/fpd.conf
+sed -i 's/^BatchSubmissionSize[[:space:]]*=[[:space:]]*.*/BatchSubmissionSize = 250/' /data/fpd/fpd.conf
+sed -i 's/^BufferSize[[:space:]]*=[[:space:]]*.*/BufferSize = 10000/' /data/fpd/fpd.conf
+sed -i 's/^PollInterval[[:space:]]*=[[:space:]]*.*/PollInterval = 200ms/' /data/fpd/fpd.conf
 
 if sed -n '/\[chainpollerconfig\]/,/^\[/p' /data/fpd/fpd.conf | grep -q 'PollSize'; then
   # Update the existing PollSize value
@@ -30,7 +29,10 @@ else
 fi
 
 # Add GRPCMaxContentLength and UnsafeResetLastVotedHeight if not present
-if ! grep -q '^GRPCMaxContentLength' /data/fpd/fpd.conf; then
+if grep -q '^GRPCMaxContentLength' /data/fpd/fpd.conf; then
+  sed -i 's/^GRPCMaxContentLength[[:space:]]*=[[:space:]]*.*/GRPCMaxContentLength = 16777216/' /data/fpd/fpd.conf
+  sed -i 's/^UnsafeResetLastVotedHeight[[:space:]]*=[[:space:]]*.*/UnsafeResetLastVotedHeight = true/' /data/fpd/fpd.conf
+else
   cat <<EOF >> /data/fpd/fpd.conf
 [Application Options]
 ; The maximum size of the gRPC message in bytes.
@@ -39,10 +41,6 @@ GRPCMaxContentLength = 16777216
 ; WARNING: If set to 'true', resets the finality provider's last voted height to the calculated start height from poller. WARNING
 UnsafeResetLastVotedHeight = true
 EOF
-else
-  # Update existing GRPCMaxContentLength value to 16777216 and UnsafeResetLastVotedHeight to true
-  sed -i 's/^\(\s*GRPCMaxContentLength\s*=\s*\).*/\1 16777216/' /data/fpd/fpd.conf
-  sed -i 's/^\(\s*UnsafeResetLastVotedHeight\s*=\s*\).*/\1 true/' /data/fpd/fpd.conf
 fi
 
 

--- a/fpd/docker-entrypoint.sh
+++ b/fpd/docker-entrypoint.sh
@@ -19,6 +19,8 @@ sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/fpd/fpd.
 sed -i 's/^BatchSubmissionSize[[:space:]]*=[[:space:]]*.*/BatchSubmissionSize = 250/' /data/fpd/fpd.conf
 sed -i 's/^BufferSize[[:space:]]*=[[:space:]]*.*/BufferSize = 10000/' /data/fpd/fpd.conf
 sed -i 's/^PollInterval[[:space:]]*=[[:space:]]*.*/PollInterval = 200ms/' /data/fpd/fpd.conf
+sed -i 's/^TimestampingDelayBlocks[[:space:]]*=[[:space:]]*.*/TimestampingDelayBlocks = 60000/' /data/fpd/fpd.conf
+sed -i 's/^NumPubRand[[:space:]]*=[[:space:]]*.*/NumPubRand = 100000/' /data/fpd/fpd.conf
 
 if sed -n '/\[chainpollerconfig\]/,/^\[/p' /data/fpd/fpd.conf | grep -q 'PollSize'; then
   # Update the existing PollSize value


### PR DESCRIPTION
Babylon informed us of a hotfix for all finality providers.  This PR is adding new config values and updating existing values to both the eots and fpd configs.

Did testing locally on the `sed` commands to make sure they are substituting correctly.

https://galaxydig.atlassian.net/browse/BCE-6965

