### PR TITLE
BCE-7866 add in two new blocks to the eotsd and fpd configs for the 1.0.3 upgrade

### DIFF
--- a/default.env
+++ b/default.env
@@ -28,6 +28,10 @@ WS_PORT=8546
 EOTSD_PORT=12582
 FPD_PORT=12581
 
+# base64 encoded 32-byte key for HMAC security
+# https://github.com/babylonlabs-io/finality-provider/blob/main/docs/hmac-security.md
+HMAC_KEY=
+
 # Only need to change in distributed setups or modified ports.
 BABYLOND_HOST=http://babylon:26657
 EOTSD_HOST=eotsd:12582

--- a/eotsd.yml
+++ b/eotsd.yml
@@ -20,6 +20,7 @@ services:
       - LOG_LEVEL=debug
       - MONIKER=${MONIKER}
       - EXTRA_FLAGS=${EOTSD_EXTRA_FLAGS}
+      - NETWORK=${NETWORK}
     ports:
       - ${EOTSD_PORT}:${EOTSD_PORT}
     volumes:

--- a/eotsd.yml
+++ b/eotsd.yml
@@ -21,6 +21,7 @@ services:
       - MONIKER=${MONIKER}
       - EXTRA_FLAGS=${EOTSD_EXTRA_FLAGS}
       - NETWORK=${NETWORK}
+      - HMAC_KEY=${HMAC_KEY}
     ports:
       - ${EOTSD_PORT}:${EOTSD_PORT}
     volumes:

--- a/eotsd/docker-entrypoint.sh
+++ b/eotsd/docker-entrypoint.sh
@@ -37,7 +37,7 @@ fi
 
 # Update HMACKey value
 if grep -q '^HMACKey' /data/eotsd/eotsd.conf; then
-  sed -i "s/^HMACKey[[:space:]]*=[[:space:]]*.*/HMACKey = ${HMAC_KEY}/" /data/eotsd/eotsd.conf
+  sed -i "s|^HMACKey[[:space:]]*=[[:space:]]*.*|HMACKey = ${HMAC_KEY}|" /data/eotsd/eotsd.conf
 fi
 
 if [ "$NETWORK" = "bbn-test-5" ]; then

--- a/eotsd/docker-entrypoint.sh
+++ b/eotsd/docker-entrypoint.sh
@@ -23,6 +23,18 @@ NoFreelistSync = false
 EOF
 fi
 
+# Add or update DisableUnsafeEndpoints under [Application Options]
+if grep -q '^\[Application Options\]' /data/eotsd/eotsd.conf; then
+  # Section exists, check if DisableUnsafeEndpoints is present
+  if grep -q '^DisableUnsafeEndpoints' /data/eotsd/eotsd.conf; then
+    # Update existing value
+    sed -i 's/^DisableUnsafeEndpoints[[:space:]]*=[[:space:]]*.*/DisableUnsafeEndpoints = true/' /data/eotsd/eotsd.conf
+  else
+    # Add it after the [Application Options] line
+    sed -i '/^\[Application Options\]/a DisableUnsafeEndpoints = true' /data/eotsd/eotsd.conf
+  fi
+fi
+
 if [ "$NETWORK" = "bbn-test-5" ]; then
   # Add GRPCMaxContentLength if not present
   if grep -q '^GRPCMaxContentLength' /data/eotsd/eotsd.conf; then

--- a/eotsd/docker-entrypoint.sh
+++ b/eotsd/docker-entrypoint.sh
@@ -11,6 +11,18 @@ fi
 echo "Initialization complete. Ready to start eotsd."
 
 sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/eotsd/eotsd.conf
+
+# Add NoFreelistSync if not present
+if grep -q '^NoFreelistSync' /data/eotsd/eotsd.conf; then
+  # Update existing NoFreelistSync value to false
+  sed -i 's/^NoFreelistSync[[:space:]]*=[[:space:]]*.*/NoFreelistSync = false/' /data/eotsd/eotsd.conf
+else
+  cat <<EOF >> /data/eotsd/eotsd.conf
+[dbconfig]
+NoFreelistSync = false
+EOF
+fi
+
 if [ "$NETWORK" = "bbn-test-5" ]; then
   # Add GRPCMaxContentLength if not present
   if grep -q '^GRPCMaxContentLength' /data/eotsd/eotsd.conf; then

--- a/eotsd/docker-entrypoint.sh
+++ b/eotsd/docker-entrypoint.sh
@@ -35,6 +35,11 @@ if grep -q '^\[Application Options\]' /data/eotsd/eotsd.conf; then
   fi
 fi
 
+# Update HMACKey value
+if grep -q '^HMACKey' /data/eotsd/eotsd.conf; then
+  sed -i "s/^HMACKey[[:space:]]*=[[:space:]]*.*/HMACKey = ${HMAC_KEY}/" /data/eotsd/eotsd.conf
+fi
+
 if [ "$NETWORK" = "bbn-test-5" ]; then
   # Add GRPCMaxContentLength if not present
   if grep -q '^GRPCMaxContentLength' /data/eotsd/eotsd.conf; then

--- a/fpd.yml
+++ b/fpd.yml
@@ -27,6 +27,7 @@ services:
       - NETWORK=${NETWORK}
       - BABYLOND_HOST=${BABYLOND_HOST}
       - EOTSD_HOST=${EOTSD_HOST}
+      - HMAC_KEY=${HMAC_KEY}
     ports:
       - ${FPD_PORT}:${FPD_PORT}
     volumes:

--- a/fpd/docker-entrypoint.sh
+++ b/fpd/docker-entrypoint.sh
@@ -31,7 +31,7 @@ fi
 
 # Update HMACKey value
 if grep -q '^HMACKey' /data/fpd/fpd.conf; then
-  sed -i "s/^HMACKey[[:space:]]*=[[:space:]]*.*/HMACKey = ${HMAC_KEY}/" /data/fpd/fpd.conf
+  sed -i "s|^HMACKey[[:space:]]*=[[:space:]]*.*|HMACKey = ${HMAC_KEY}|" /data/fpd/fpd.conf
 fi
 
 if sed -n '/\[chainpollerconfig\]/,/^\[/p' /data/fpd/fpd.conf | grep -q 'PollSize'; then

--- a/fpd/docker-entrypoint.sh
+++ b/fpd/docker-entrypoint.sh
@@ -18,6 +18,17 @@ sed -i "s|^ChainID = .*|ChainID = ${NETWORK}|" /data/fpd/fpd.conf
 sed -i '/^\[metrics\]/,/^\[/{ /^[^[]/ s/127\.0\.0\.1/0.0.0.0/g }' /data/fpd/fpd.conf
 sed -i 's/^\(\s*BatchSubmissionSize\s*=\s*\).*/\1 100/' /data/fpd/fpd.conf
 
+# Add NoFreelistSync if not present
+if grep -q '^NoFreelistSync' /data/fpd/fpd.conf; then
+  # Update existing NoFreelistSync value to false
+  sed -i 's/^NoFreelistSync[[:space:]]*=[[:space:]]*.*/NoFreelistSync = false/' /data/fpd/fpd.conf
+else
+  cat <<EOF >> /data/fpd/fpd.conf
+[dbconfig]
+NoFreelistSync = false
+EOF
+fi
+
 if sed -n '/\[chainpollerconfig\]/,/^\[/p' /data/fpd/fpd.conf | grep -q 'PollSize'; then
   # Update the existing PollSize value
   sed -i '/\[chainpollerconfig\]/,/\[/ s/^\(\s*PollSize\s*=\s*\).*/\1 100/' /data/fpd/fpd.conf

--- a/fpd/docker-entrypoint.sh
+++ b/fpd/docker-entrypoint.sh
@@ -29,6 +29,11 @@ NoFreelistSync = false
 EOF
 fi
 
+# Update HMACKey value
+if grep -q '^HMACKey' /data/fpd/fpd.conf; then
+  sed -i "s/^HMACKey[[:space:]]*=[[:space:]]*.*/HMACKey = ${HMAC_KEY}/" /data/fpd/fpd.conf
+fi
+
 if sed -n '/\[chainpollerconfig\]/,/^\[/p' /data/fpd/fpd.conf | grep -q 'PollSize'; then
   # Update the existing PollSize value
   sed -i '/\[chainpollerconfig\]/,/\[/ s/^\(\s*PollSize\s*=\s*\).*/\1 100/' /data/fpd/fpd.conf


### PR DESCRIPTION
* Add in new conf values for the 1.0.3 and 1.0.4 hotfix upgrades of the finality provider software
* `hmac_key` authentication is now required between the eots and fp clients.  Followed [this doc](https://github.com/babylonlabs-io/finality-provider/blob/main/docs/hmac-security.md) to enable it here
* setting a value to disallow unsafe endpoints in the EOTS config

Tested successfully on the DR node 
```
eotsd-1  | 2025-12-11T20:11:50.153073Z	info	HMAC authentication enabled for gRPC server
```

