### PR TITLE
BCE-8239 emergency security fix to allow for loading babylond from local source

### DIFF
--- a/babylon.yml
+++ b/babylon.yml
@@ -8,6 +8,7 @@ x-logging: &logging
 
 services:
   builder:
+    profiles: ["skip"]
     restart: "no"
     build:
       context: ./builder
@@ -24,12 +25,11 @@ services:
   babylon:
     build:
       context: ./babylon
-      dockerfile: Dockerfile.source
+      dockerfile: Dockerfile.temporary
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
-        - BABYLON_BUILD_OPTIONS=${BABYLON_BUILD_OPTIONS}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: babylon
     restart: unless-stopped
@@ -61,9 +61,6 @@ services:
       - UNSAFE_SKIP_BACKUP=true
     ports:
       - ${CL_P2P_PORT:-26656}:${CL_P2P_PORT:-26656}/tcp
-    depends_on:
-      builder:
-        condition: service_completed_successfully
     <<: *logging
     volumes:
       - consensus-data:/cosmos
@@ -127,11 +124,11 @@ services:
     profiles: ["tools"]
     build:
       context: ./babylon
-      dockerfile: Dockerfile.source
+      dockerfile: Dockerfile.temporary
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: babylon
     environment:
@@ -167,11 +164,11 @@ services:
     profiles: ["tools"]
     build:
       context: ./babylon
-      dockerfile: Dockerfile.source
+      dockerfile: Dockerfile.temporary
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: babylon
     environment:
@@ -188,11 +185,11 @@ services:
     profiles: ["tools"]
     build:
       context: ./babylon
-      dockerfile: Dockerfile.source
+      dockerfile: Dockerfile.temporary
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: root
     volumes:
@@ -210,11 +207,11 @@ services:
     profiles: ["tools"]
     build:
       context: ./babylon
-      dockerfile: Dockerfile.source
+      dockerfile: Dockerfile.temporary
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: root
     volumes:
@@ -234,11 +231,11 @@ services:
     profiles: ["tools"]
     build:
       context: ./babylon
-      dockerfile: Dockerfile.source
+      dockerfile: Dockerfile.temporary
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: root
     volumes:
@@ -256,11 +253,11 @@ services:
     profiles: ["tools"]
     build:
       context: ./babylon
-      dockerfile: Dockerfile.source
+      dockerfile: Dockerfile.temporary
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: root
     volumes:
@@ -277,11 +274,11 @@ services:
     profiles: ["tools"]
     build:
       context: ./babylon
-      dockerfile: Dockerfile.source
+      dockerfile: Dockerfile.temporary
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: root
     volumes:
@@ -301,10 +298,9 @@ services:
       context: ./babylon
       dockerfile: Dockerfile.source
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
-        - BABYLON_BUILD_OPTIONS=${BABYLON_BUILD_OPTIONS}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: root
     volumes:
@@ -324,10 +320,9 @@ services:
       context: ./babylon
       dockerfile: Dockerfile.source
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
-        - BABYLON_BUILD_OPTIONS=${BABYLON_BUILD_OPTIONS}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: root
     volumes:
@@ -344,11 +339,11 @@ services:
     profiles: ["tools"]
     build:
       context: ./babylon
-      dockerfile: Dockerfile.source
+      dockerfile: Dockerfile.temporary
       args:
-        - DAEMON_VERSION=${BABYLON_NODE_VERSION}
+        - DAEMON_VERSION=temporary
         - USER=babylon
-    image: babylon:local-${BABYLON_NODE_VERSION}
+    image: babylon:local-temporary
     pull_policy: never
     user: babylon
     volumes:

--- a/babylon/Dockerfile.temporary
+++ b/babylon/Dockerfile.temporary
@@ -1,0 +1,54 @@
+# Get dasel
+FROM ghcr.io/tomwright/dasel:2-alpine AS dasel
+
+# Use pre-built binary instead of building from source
+FROM alpine:3.14
+
+ARG USER=babylon
+ARG UID=10001
+ARG COSMOVISOR_VERSION=v1.6.0
+ARG DAEMON_VERSION=temporary
+
+ENV VERSION_NUMBER=${DAEMON_VERSION}
+
+RUN apk update && apk add --no-cache ca-certificates tzdata bash curl wget lz4 jq tar aria2
+
+# See https://stackoverflow.com/a/55757473/12429735RUN
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --shell "/sbin/nologin" \
+    --uid "${UID}" \
+    "${USER}"
+
+# Install cosmovisor
+RUN wget https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2F${COSMOVISOR_VERSION}/cosmovisor-${COSMOVISOR_VERSION}-linux-amd64.tar.gz
+RUN tar xf cosmovisor-${COSMOVISOR_VERSION}-linux-amd64.tar.gz
+RUN mv cosmovisor /usr/local/bin
+
+VOLUME /cosmos
+
+RUN mkdir -p /cosmos/cosmovisor/genesis/bin
+RUN mkdir /cosmos/cosmovisor/upgrades
+RUN mkdir /cosmos/config
+RUN mkdir /cosmos/data
+
+# Copy pre-built binary from local disk
+# Place your babylond binary in the babylon/ directory before building
+COPY --chown=${USER}:${USER} babylond /usr/local/bin/babylond
+RUN chmod +x /usr/local/bin/babylond
+
+COPY --from=dasel --chown=${USER}:${USER} /usr/local/bin/dasel /usr/local/bin/
+
+# Set correct permissions
+RUN chown -R ${USER}:${USER} /cosmos && chmod -R 700 /cosmos
+
+# Cannot assume buildkit, hence no chmod
+COPY ./docker-entrypoint.sh /usr/local/bin/
+
+# Belt and suspenders
+RUN chmod -R 755 /usr/local/bin/*
+
+USER ${USER}
+
+ENTRYPOINT ["babylond", "--home", "/cosmos"]


### PR DESCRIPTION
Creating a temporary workaround for a security hotfix to load the binary from local source instead of building

Tested on the DR server and this works.